### PR TITLE
Implement chunk queries

### DIFF
--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -4922,7 +4922,8 @@ func Test_ChunkQuerier_OOOQuery(t *testing.T) {
 
 func test_ChunkQuerier_OOOQuery(t *testing.T,
 	appendFunc func(app storage.Appender, ts int64) (storage.SeriesRef, error),
-	sampleFunc func(ts int64) tsdbutil.Sample) {
+	sampleFunc func(ts int64) tsdbutil.Sample,
+) {
 	opts := DefaultOptions()
 	opts.OutOfOrderCapMax = 30
 	opts.OutOfOrderTimeWindow = 24 * time.Hour.Milliseconds()

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -4901,6 +4901,17 @@ func Test_ChunkQuerier_OOOQuery(t *testing.T) {
 				return sample{t: ts, fh: tsdbutil.GenerateTestFloatHistogram(int(ts))}
 			},
 		},
+		"integer histogram counter resets": {
+			// Adding counter reset to all histograms means each histogram will have its own chunk.
+			appendFunc: func(app storage.Appender, ts int64) (storage.SeriesRef, error) {
+				h := tsdbutil.GenerateTestHistogram(int(ts))
+				h.CounterResetHint = histogram.CounterReset
+				return app.AppendHistogram(0, labels.FromStrings("foo", "bar1"), ts, h, nil)
+			},
+			sampleFunc: func(ts int64) tsdbutil.Sample {
+				return sample{t: ts, h: tsdbutil.GenerateTestHistogram(int(ts))}
+			},
+		},
 	}
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) {

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -1695,7 +1695,7 @@ func (s *memSeries) mmapCurrentOOOHeadChunk(chunkDiskMapper *chunks.ChunkDiskMap
 	}
 	chunkRefs := make([]chunks.ChunkDiskMapperRef, 0, 1)
 	for _, memchunk := range chks {
-		chunkRef := chunkDiskMapper.WriteChunk(s.ref, s.ooo.oooHeadChunk.minTime, s.ooo.oooHeadChunk.maxTime, memchunk.chunk, true, handleChunkWriteError)
+		chunkRef := chunkDiskMapper.WriteChunk(s.ref, memchunk.minTime, memchunk.maxTime, memchunk.chunk, true, handleChunkWriteError)
 		chunkRefs = append(chunkRefs, chunkRef)
 		s.ooo.oooMmappedChunks = append(s.ooo.oooMmappedChunks, &mmappedChunk{
 			ref:        chunkRef,

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -472,7 +472,7 @@ func (s *memSeries) oooMergedChunk(meta chunks.Meta, cdm *chunks.ChunkDiskMapper
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to convert ooo head chunk to xor chunk")
 			}
-			c.meta.Chunk = chks[0].chunk
+			c.meta.Chunk = chks[0].chunk // TODO(histogram) handle multi chunk case.
 		} else {
 			chk, err := cdm.Chunk(c.ref)
 			if err != nil {

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -463,15 +463,17 @@ func (s *memSeries) oooMergedChunk(meta chunks.Meta, cdm *chunks.ChunkDiskMapper
 			// If head chunk min and max time match the meta OOO markers
 			// that means that the chunk has not expanded so we can append
 			// it as it is.
-			if s.ooo.oooHeadChunk.minTime == meta.OOOLastMinTime && s.ooo.oooHeadChunk.maxTime == meta.OOOLastMaxTime {
-				xor, err = s.ooo.oooHeadChunk.chunk.ToXOR() // TODO(jesus.vazquez) (This is an optimization idea that has no priority and might not be that useful) See if we could use a copy of the underlying slice. That would leave the more expensive ToXOR() function only for the usecase where Bytes() is called.
-			} else {
-				// We need to remove samples that are outside of the markers
-				xor, err = s.ooo.oooHeadChunk.chunk.ToXORBetweenTimestamps(meta.OOOLastMinTime, meta.OOOLastMaxTime)
-			}
+			chks, err := s.ooo.oooHeadChunk.chunk.ToEncodedChunks(meta.OOOLastMinTime, meta.OOOLastMaxTime)
+			// if s.ooo.oooHeadChunk.minTime == meta.OOOLastMinTime && s.ooo.oooHeadChunk.maxTime == meta.OOOLastMaxTime {
+			// 	xor, err = s.ooo.oooHeadChunk.chunk.ToXOR() // TODO(jesus.vazquez) (This is an optimization idea that has no priority and might not be that useful) See if we could use a copy of the underlying slice. That would leave the more expensive ToXOR() function only for the usecase where Bytes() is called.
+			// } else {
+			// 	// We need to remove samples that are outside of the markers
+			// 	xor, err = s.ooo.oooHeadChunk.chunk.ToXORBetweenTimestamps(meta.OOOLastMinTime, meta.OOOLastMaxTime)
+			// }
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to convert ooo head chunk to xor chunk")
 			}
+			xor = chks[0].chunk.(*chunkenc.XORChunk)
 			c.meta.Chunk = xor
 		} else {
 			chk, err := cdm.Chunk(c.ref)
@@ -491,8 +493,9 @@ func (s *memSeries) oooMergedChunk(meta chunks.Meta, cdm *chunks.ChunkDiskMapper
 			} else {
 				c.meta.Chunk = chk
 			}
+			mc.chunks = append(mc.chunks, c.meta)
 		}
-		mc.chunks = append(mc.chunks, c.meta)
+
 		if c.meta.MaxTime > absoluteMax {
 			absoluteMax = c.meta.MaxTime
 		}

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -459,7 +459,6 @@ func (s *memSeries) oooMergedChunk(meta chunks.Meta, cdm *chunks.ChunkDiskMapper
 			continue
 		}
 		if c.meta.Ref == oooHeadRef {
-			var xor *chunkenc.XORChunk
 			// If head chunk min and max time match the meta OOO markers
 			// that means that the chunk has not expanded so we can append
 			// it as it is.
@@ -473,8 +472,7 @@ func (s *memSeries) oooMergedChunk(meta chunks.Meta, cdm *chunks.ChunkDiskMapper
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to convert ooo head chunk to xor chunk")
 			}
-			xor = chks[0].chunk.(*chunkenc.XORChunk)
-			c.meta.Chunk = xor
+			c.meta.Chunk = chks[0].chunk
 		} else {
 			chk, err := cdm.Chunk(c.ref)
 			if err != nil {
@@ -493,9 +491,8 @@ func (s *memSeries) oooMergedChunk(meta chunks.Meta, cdm *chunks.ChunkDiskMapper
 			} else {
 				c.meta.Chunk = chk
 			}
-			mc.chunks = append(mc.chunks, c.meta)
 		}
-
+		mc.chunks = append(mc.chunks, c.meta)
 		if c.meta.MaxTime > absoluteMax {
 			absoluteMax = c.meta.MaxTime
 		}

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -4243,9 +4243,10 @@ func TestOOOWalReplay(t *testing.T) {
 	require.False(t, ok)
 	require.NotNil(t, ms)
 
-	xor, err := ms.ooo.oooHeadChunk.chunk.ToXOR()
+	chks, err := ms.ooo.oooHeadChunk.chunk.ToEncodedChunks(math.MinInt64, math.MaxInt64)
 	require.NoError(t, err)
-
+	require.Len(t, chks, 1)
+	xor := chks[0].chunk.(*chunkenc.XORChunk)
 	it := xor.Iterator(nil)
 	actOOOSamples := make([]sample, 0, len(expOOOSamples))
 	for it.Next() == chunkenc.ValFloat {

--- a/tsdb/ooo_head.go
+++ b/tsdb/ooo_head.go
@@ -72,7 +72,7 @@ func (o *OOOChunk) NumSamples() int {
 	return len(o.samples)
 }
 
-// ToChunk returns chunks with the samples in the OOOChunk.
+// ToEncodedChunks returns chunks with the samples in the OOOChunk.
 func (o *OOOChunk) ToEncodedChunks(mint, maxt int64) (chks []memChunk, err error) {
 	if len(o.samples) == 0 {
 		return nil, nil

--- a/tsdb/ooo_head.go
+++ b/tsdb/ooo_head.go
@@ -72,136 +72,20 @@ func (o *OOOChunk) NumSamples() int {
 	return len(o.samples)
 }
 
-func (o *OOOChunk) ToXOR() (*chunkenc.XORChunk, error) {
-	x := chunkenc.NewXORChunk()
-	app, err := x.Appender()
-	if err != nil {
-		return nil, err
+// ToChunk returns chunks with the samples in the OOOChunk.
+func (o *OOOChunk) ToEncodedChunks(mint, maxt int64) (chks []memChunk, err error) {
+	if len(o.samples) == 0 {
+		return nil, nil
 	}
-	for _, s := range o.samples {
-		app.Append(s.t, s.f)
-	}
-	return x, nil
-}
-
-func (o *OOOChunk) ToXORBetweenTimestamps(mint, maxt int64) (*chunkenc.XORChunk, error) {
-	x := chunkenc.NewXORChunk()
-	app, err := x.Appender()
-	if err != nil {
-		return nil, err
-	}
-	for _, s := range o.samples {
-		if s.t < mint {
-			continue
-		}
-		if s.t > maxt {
-			break
-		}
-		app.Append(s.t, s.f)
-	}
-	return x, nil
-}
-
-func (o *OOOChunk) ToHistogram() ([]*chunkenc.HistogramChunk, []int64, []int64, error) {
-	ch, err := chunkenc.NewEmptyChunk(chunkenc.EncHistogram)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	chunkCreated := true
-	chunks := []*chunkenc.HistogramChunk{}
-	minTimes := []int64{}
-	minT := int64(0)
-	maxTimes := []int64{}
-	maxT := int64(0)
-	appender, err := ch.Appender()
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	app := appender.(*chunkenc.HistogramAppender)
+	// The most common case is that there will be a single chunk, with the same type of samples in it - this is always true for float samples.
+	chks = make([]memChunk, 0, 1)
 	var (
-		pForwardInserts, nForwardInserts   []chunkenc.Insert
-		pBackwardInserts, nBackwardInserts []chunkenc.Insert
-		pMergedSpans, nMergedSpans         []histogram.Span
-		okToAppend, counterReset, gauge    bool
+		cmint int64
+		cmaxt int64
+		chunk chunkenc.Chunk
+		app   chunkenc.Appender
 	)
-	for _, s := range o.samples {
-		switch {
-		case s.h == nil:
-			return nil, nil, nil, fmt.Errorf("mixing integer histograms and other types in OOO is not allowed")
-		case s.h.CounterResetHint == histogram.GaugeType:
-			pForwardInserts, nForwardInserts,
-				pBackwardInserts, nBackwardInserts,
-				pMergedSpans, nMergedSpans,
-				okToAppend = app.AppendableGauge(s.h)
-		case s.h.CounterResetHint == histogram.CounterReset:
-			counterReset = true
-		default:
-			pForwardInserts, nForwardInserts, okToAppend, counterReset = app.Appendable(s.h)
-		}
-
-		if !chunkCreated {
-			if len(pBackwardInserts)+len(nBackwardInserts) > 0 {
-				s.h.PositiveSpans = pMergedSpans
-				s.h.NegativeSpans = nMergedSpans
-				app.RecodeHistogram(s.h, pBackwardInserts, nBackwardInserts)
-			}
-			// We have 3 cases here
-			// - !okToAppend or counterReset -> We need to cut a new chunk.
-			// - okToAppend but we have inserts → Existing chunk needs
-			//   recoding before we can append our histogram.
-			// - okToAppend and no inserts → Chunk is ready to support our histogram.
-			switch {
-			case !okToAppend || counterReset:
-				chunks = append(chunks, ch.(*chunkenc.HistogramChunk))
-				minTimes = append(minTimes, minT)
-				maxTimes = append(maxTimes, maxT)
-				ch = chunkenc.NewHistogramChunk()
-				minT = s.t
-				maxT = s.t
-				chunkCreated = true
-			case len(pForwardInserts) > 0 || len(nForwardInserts) > 0:
-				// New buckets have appeared. We need to recode all
-				// prior histogram samples within the chunk before we
-				// can process this one.
-				var newApp chunkenc.Appender
-				ch, newApp = app.Recode(
-					pForwardInserts, nForwardInserts,
-					s.h.PositiveSpans, s.h.NegativeSpans,
-				)
-				app = newApp.(*chunkenc.HistogramAppender)
-			}
-		}
-
-		if chunkCreated {
-			minT = s.t
-			maxT = s.t
-			hc := ch.(*chunkenc.HistogramChunk)
-			header := chunkenc.UnknownCounterReset
-			switch {
-			case gauge:
-				header = chunkenc.GaugeType
-			case counterReset:
-				header = chunkenc.CounterReset
-			case okToAppend:
-				header = chunkenc.NotCounterReset
-			}
-			hc.SetCounterResetHeader(header)
-		}
-
-		app.AppendHistogram(s.t, s.h)
-	}
-	chunks = append(chunks, ch.(*chunkenc.HistogramChunk))
-	minTimes = append(minTimes, minT)
-	maxTimes = append(maxTimes, maxT)
-	return chunks, minTimes, maxTimes, nil
-}
-
-func (o *OOOChunk) ToHistogramBetweenTimestamps(mint, maxt int64) ([]*chunkenc.HistogramChunk, error) {
-	ch := chunkenc.NewHistogramChunk()
-	app, err := ch.Appender()
-	if err != nil {
-		return nil, err
-	}
+	prevEncoding := chunkenc.EncNone // Yes we could call the chunk for this, but this is more efficient.
 	for _, s := range o.samples {
 		if s.t < mint {
 			continue
@@ -209,121 +93,184 @@ func (o *OOOChunk) ToHistogramBetweenTimestamps(mint, maxt int64) ([]*chunkenc.H
 		if s.t > maxt {
 			break
 		}
-		app.AppendHistogram(s.t, s.h)
-	}
-	return nil, nil // TODO Fix
-}
-
-func (o *OOOChunk) ToFloatHistogram() ([]*chunkenc.FloatHistogramChunk, []int64, []int64, error) {
-	ch, err := chunkenc.NewEmptyChunk(chunkenc.EncFloatHistogram)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	chunkCreated := true
-	chunks := []*chunkenc.FloatHistogramChunk{}
-	minTimes := []int64{}
-	minT := int64(0)
-	maxTimes := []int64{}
-	maxT := int64(0)
-	appender, err := ch.Appender()
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	app := appender.(*chunkenc.FloatHistogramAppender)
-	var (
-		pForwardInserts, nForwardInserts   []chunkenc.Insert
-		pBackwardInserts, nBackwardInserts []chunkenc.Insert
-		pMergedSpans, nMergedSpans         []histogram.Span
-		okToAppend, counterReset, gauge    bool
-	)
-	for _, s := range o.samples {
-		switch {
-		case s.fh == nil:
-			return nil, nil, nil, fmt.Errorf("mixing float histograms and other types in OOO is not allowed")
-		case s.fh.CounterResetHint == histogram.GaugeType:
-			pForwardInserts, nForwardInserts,
-				pBackwardInserts, nBackwardInserts,
-				pMergedSpans, nMergedSpans,
-				okToAppend = app.AppendableGauge(s.fh)
-		case s.fh.CounterResetHint == histogram.CounterReset:
-			counterReset = true
-		default:
-			pForwardInserts, nForwardInserts, okToAppend, counterReset = app.Appendable(s.fh)
+		encoding := chunkenc.EncXOR
+		if s.h != nil {
+			encoding = chunkenc.EncHistogram
+		} else if s.fh != nil {
+			encoding = chunkenc.EncFloatHistogram
 		}
-
-		if !chunkCreated {
-			if len(pBackwardInserts)+len(nBackwardInserts) > 0 {
-				s.fh.PositiveSpans = pMergedSpans
-				s.fh.NegativeSpans = nMergedSpans
-				app.RecodeHistogramm(s.fh, pBackwardInserts, nBackwardInserts)
+		created := false
+		if encoding != prevEncoding { // For the first sample, this will always be true as EncNone != EncXOR | EncHistogram | EncFloatHistogram
+			if prevEncoding != chunkenc.EncNone {
+				chks = append(chks, memChunk{chunk, cmint, cmaxt})
 			}
-			// We have 3 cases here
-			// - !okToAppend or counterReset -> We need to cut a new chunk.
-			// - okToAppend but we have inserts → Existing chunk needs
-			//   recoding before we can append our histogram.
-			// - okToAppend and no inserts → Chunk is ready to support our histogram.
-			switch {
-			case !okToAppend || counterReset:
-				chunks = append(chunks, ch.(*chunkenc.FloatHistogramChunk))
-				minTimes = append(minTimes, minT)
-				maxTimes = append(maxTimes, maxT)
-				ch = chunkenc.NewFloatHistogramChunk()
-				minT = s.t
-				maxT = s.t
-				chunkCreated = true
-			case len(pForwardInserts) > 0 || len(nForwardInserts) > 0:
-				// New buckets have appeared. We need to recode all
-				// prior histogram samples within the chunk before we
-				// can process this one.
-				var newApp chunkenc.Appender
-				ch, newApp = app.Recode(
-					pForwardInserts, nForwardInserts,
-					s.fh.PositiveSpans, s.fh.NegativeSpans,
+			cmint = s.t
+			switch encoding {
+			case chunkenc.EncXOR:
+				chunk = chunkenc.NewXORChunk()
+			case chunkenc.EncHistogram:
+				chunk = chunkenc.NewHistogramChunk()
+			case chunkenc.EncFloatHistogram:
+				chunk = chunkenc.NewFloatHistogramChunk()
+			}
+			app, err = chunk.Appender()
+			if err != nil {
+				return
+			}
+			created = true
+		}
+		switch encoding {
+		case chunkenc.EncXOR:
+			// shortcut for XOR
+			app.Append(s.t, s.f)
+		case chunkenc.EncHistogram:
+			var okToAppend, counterReset, gauge bool
+			if created {
+				okToAppend = true
+				switch s.h.CounterResetHint {
+				case histogram.GaugeType:
+					gauge = true
+				case histogram.CounterReset:
+					counterReset = true
+				}
+			} else { // Not a new chunk, must check for appendable.
+				happ := app.(*chunkenc.HistogramAppender)
+				var (
+					pForwardInserts, nForwardInserts   []chunkenc.Insert
+					pBackwardInserts, nBackwardInserts []chunkenc.Insert
+					pMergedSpans, nMergedSpans         []histogram.Span
 				)
-				app = newApp.(*chunkenc.FloatHistogramAppender)
+				switch s.h.CounterResetHint {
+				case histogram.GaugeType:
+					pForwardInserts, nForwardInserts,
+						pBackwardInserts, nBackwardInserts,
+						pMergedSpans, nMergedSpans,
+						okToAppend = happ.AppendableGauge(s.h)
+				case histogram.CounterReset:
+					counterReset = true
+				default:
+					pForwardInserts, nForwardInserts, okToAppend, counterReset = happ.Appendable(s.h)
+				}
+
+				if len(pBackwardInserts)+len(nBackwardInserts) > 0 {
+					s.h.PositiveSpans = pMergedSpans
+					s.h.NegativeSpans = nMergedSpans
+					happ.RecodeHistogram(s.h, pBackwardInserts, nBackwardInserts)
+				}
+				// We have 3 cases here
+				// - !okToAppend or counterReset -> We need to cut a new chunk.
+				// - okToAppend but we have inserts → Existing chunk needs
+				//   recoding before we can append our histogram.
+				// - okToAppend and no inserts → Chunk is ready to support our histogram.
+				switch {
+				case !okToAppend || counterReset:
+					chks = append(chks, memChunk{chunk, cmint, cmaxt})
+					chunk = chunkenc.NewHistogramChunk()
+					cmint = s.t
+					created = true
+				case len(pForwardInserts) > 0 || len(nForwardInserts) > 0:
+					// New buckets have appeared. We need to recode all
+					// prior histogram samples within the chunk before we
+					// can process this one.
+					chunk, app = happ.Recode(
+						pForwardInserts, nForwardInserts,
+						s.h.PositiveSpans, s.h.NegativeSpans,
+					)
+				}
 			}
-		}
 
-		if chunkCreated {
-			minT = s.t
-			maxT = s.t
-			hc := ch.(*chunkenc.FloatHistogramChunk)
-			header := chunkenc.UnknownCounterReset
-			switch {
-			case gauge:
-				header = chunkenc.GaugeType
-			case counterReset:
-				header = chunkenc.CounterReset
-			case okToAppend:
-				header = chunkenc.NotCounterReset
+			if created {
+				hc := chunk.(*chunkenc.HistogramChunk)
+				header := chunkenc.UnknownCounterReset
+				switch {
+				case gauge:
+					header = chunkenc.GaugeType
+				case counterReset:
+					header = chunkenc.CounterReset
+				case okToAppend:
+					header = chunkenc.NotCounterReset
+				}
+				hc.SetCounterResetHeader(header)
 			}
-			hc.SetCounterResetHeader(header)
-		}
+			app.AppendHistogram(s.t, s.h)
+		case chunkenc.EncFloatHistogram:
+			var okToAppend, counterReset, gauge bool
+			if created {
+				okToAppend = true
+				switch s.fh.CounterResetHint {
+				case histogram.GaugeType:
+					gauge = true
+				case histogram.CounterReset:
+					counterReset = true
+				}
+			} else { // Not a new chunk, must check for appendable.
+				happ := app.(*chunkenc.FloatHistogramAppender)
+				var (
+					pForwardInserts, nForwardInserts   []chunkenc.Insert
+					pBackwardInserts, nBackwardInserts []chunkenc.Insert
+					pMergedSpans, nMergedSpans         []histogram.Span
+				)
+				switch s.fh.CounterResetHint {
+				case histogram.GaugeType:
+					pForwardInserts, nForwardInserts,
+						pBackwardInserts, nBackwardInserts,
+						pMergedSpans, nMergedSpans,
+						okToAppend = happ.AppendableGauge(s.fh)
+				case histogram.CounterReset:
+					counterReset = true
+				default:
+					pForwardInserts, nForwardInserts, okToAppend, counterReset = happ.Appendable(s.fh)
+				}
 
-		app.AppendFloatHistogram(s.t, s.fh)
-	}
-	chunks = append(chunks, ch.(*chunkenc.FloatHistogramChunk))
-	minTimes = append(minTimes, minT)
-	maxTimes = append(maxTimes, maxT)
-	return chunks, minTimes, maxTimes, nil
-}
+				if len(pBackwardInserts)+len(nBackwardInserts) > 0 {
+					s.fh.PositiveSpans = pMergedSpans
+					s.fh.NegativeSpans = nMergedSpans
+					happ.RecodeHistogramm(s.fh, pBackwardInserts, nBackwardInserts)
+				}
+				// We have 3 cases here
+				// - !okToAppend or counterReset -> We need to cut a new chunk.
+				// - okToAppend but we have inserts → Existing chunk needs
+				//   recoding before we can append our histogram.
+				// - okToAppend and no inserts → Chunk is ready to support our histogram.
+				switch {
+				case !okToAppend || counterReset:
+					chks = append(chks, memChunk{chunk, cmint, cmaxt})
+					chunk = chunkenc.NewFloatHistogramChunk()
+					cmint = s.t
+					created = true
+				case len(pForwardInserts) > 0 || len(nForwardInserts) > 0:
+					// New buckets have appeared. We need to recode all
+					// prior histogram samples within the chunk before we
+					// can process this one.
+					chunk, app = happ.Recode(
+						pForwardInserts, nForwardInserts,
+						s.fh.PositiveSpans, s.fh.NegativeSpans,
+					)
+				}
+			}
 
-func (o *OOOChunk) ToFloatHistogramBetweenTimestamps(mint, maxt int64) ([]*chunkenc.FloatHistogramChunk, error) {
-	ch := chunkenc.NewFloatHistogramChunk()
-	app, err := ch.Appender()
-	if err != nil {
-		return nil, err
-	}
-	for _, s := range o.samples {
-		if s.t < mint {
-			continue
+			if created {
+				hc := chunk.(*chunkenc.FloatHistogramChunk)
+				header := chunkenc.UnknownCounterReset
+				switch {
+				case gauge:
+					header = chunkenc.GaugeType
+				case counterReset:
+					header = chunkenc.CounterReset
+				case okToAppend:
+					header = chunkenc.NotCounterReset
+				}
+				hc.SetCounterResetHeader(header)
+			}
+			app.AppendFloatHistogram(s.t, s.fh)
 		}
-		if s.t > maxt {
-			break
-		}
-		app.AppendFloatHistogram(s.t, s.fh)
+		cmaxt = s.t
+		prevEncoding = encoding
 	}
-	return nil, nil // TODO Fix
+	if prevEncoding != chunkenc.EncNone {
+		chks = append(chks, memChunk{chunk, cmint, cmaxt})
+	}
+	return chks, nil
 }
 
 var _ BlockReader = &OOORangeHead{}

--- a/tsdb/ooo_head.go
+++ b/tsdb/ooo_head.go
@@ -166,6 +166,10 @@ func (o *OOOChunk) ToEncodedChunks(mint, maxt int64) (chks []memChunk, err error
 				case !okToAppend || counterReset:
 					chks = append(chks, memChunk{chunk, cmint, cmaxt})
 					chunk = chunkenc.NewHistogramChunk()
+					app, err = chunk.Appender()
+					if err != nil {
+						return
+					}
 					cmint = s.t
 					created = true
 				case len(pForwardInserts) > 0 || len(nForwardInserts) > 0:
@@ -236,6 +240,10 @@ func (o *OOOChunk) ToEncodedChunks(mint, maxt int64) (chks []memChunk, err error
 				case !okToAppend || counterReset:
 					chks = append(chks, memChunk{chunk, cmint, cmaxt})
 					chunk = chunkenc.NewFloatHistogramChunk()
+					app, err = chunk.Appender()
+					if err != nil {
+						return
+					}
 					cmint = s.t
 					created = true
 				case len(pForwardInserts) > 0 || len(nForwardInserts) > 0:

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -830,6 +830,8 @@ func (p *populateWithDelChunkSeriesIterator) Next() bool {
 			} else {
 				err = fmt.Errorf("internal error, could not unwrap safeHeadChunk to histogram chunk: %T", hc.Chunk)
 			}
+		case *mergedOOOChunks:
+			// TODO(histograms): implement
 		default:
 			err = fmt.Errorf("internal error, unknown chunk type %T when expecting histogram", p.currChkMeta.Chunk)
 		}
@@ -922,6 +924,8 @@ func (p *populateWithDelChunkSeriesIterator) Next() bool {
 			} else {
 				err = fmt.Errorf("internal error, could not unwrap safeHeadChunk to float histogram chunk: %T", hc.Chunk)
 			}
+		case *mergedOOOChunks:
+			// TODO(histograms): implement
 		default:
 			err = fmt.Errorf("internal error, unknown chunk type %T when expecting float histogram", p.currChkMeta.Chunk)
 		}


### PR DESCRIPTION
Remove type specific chunk encoding functions from ooo head. Have a single ToEncodedChunks.
Allow reading multiple chunks from ooo head.
Other small fixes.